### PR TITLE
컨트롤러 관련 내용 수강 완료

### DIFF
--- a/note/section0.md
+++ b/note/section0.md
@@ -5,6 +5,80 @@
 ## 프로젝트 생성
 
 ## 컨트롤러 생성
+- 보통 SSR, SPA, 등을 많이 쓴다.
+- SSR -> Jsp, thymeleaf, mustache, freemarker -> html rendering
+- SPA -> VUE, react -> javascript + <-> API ( JSON )
+- test를 생성하는 경우 mac에서 인텔리제이를 사용한다면 command + shift + t
+- 위 명령어를 실행하면 테스트를 동일한 경로에 똑같이 생성해 줍니다.
+
+```java
+// 아래 세가지는 static method이므로 이렇게 불러와서 쓰거나 MockMvcRequestBuilder class를 선언해서  사용할 수 있습니다.
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+
+@WebMvcTest
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("/post 요청시 test를 출력한다.")
+    void test() throws Exception {
+        mockMvc.perform(get("/v1/posts"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("test"))
+                .andDo(print());
+    }
+}
+```
+
+- 여기서 조금 꿀팁이라고 생각되는 것은 마지막 라인의 `andDo(print())`입니다.
+- 아래 내용을 실행하면 아래내용이 실행 결과로 출력됩니다.
+
+```aidl
+MockHttpServletRequest:
+      HTTP Method = GET
+      Request URI = /v1/posts
+       Parameters = {}
+          Headers = []
+             Body = null
+    Session Attrs = {}
+
+Handler:
+             Type = com.hodolog.hodollog.controller.PostController
+           Method = com.hodolog.hodollog.controller.PostController#get()
+
+Async:
+    Async started = false
+     Async result = null
+
+Resolved Exception:
+             Type = null
+
+ModelAndView:
+        View name = null
+             View = null
+            Model = null
+
+FlashMap:
+       Attributes = null
+
+MockHttpServletResponse:
+           Status = 200
+    Error message = null
+          Headers = [Content-Type:"text/plain;charset=UTF-8", Content-Length:"4"]
+     Content type = text/plain;charset=UTF-8
+             Body = test
+    Forwarded URL = null
+   Redirected URL = null
+          Cookies = []
+BUILD SUCCESSFUL in 5s
+4 actionable tasks: 1 executed, 3 up-to-date
+12:55:45 PM: 실행이 완료되었습니다 ':test --tests "com.hodolog.hodollog.controller.PostControllerTest.test"'.
+```
 
 
 ## POST 데이터 콘텐츠 타입

--- a/src/main/java/com/hodolog/hodollog/controller/PostController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/PostController.java
@@ -1,0 +1,17 @@
+package com.hodolog.hodollog.controller;
+
+import org.hibernate.annotations.common.reflection.XMethod;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PostController {
+
+    @RequestMapping(method = RequestMethod.GET, path = "/v1/posts")
+    public String get() {
+        return "test";
+    }
+
+}

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -1,0 +1,29 @@
+package com.hodolog.hodollog.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+
+@WebMvcTest
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("/post 요청시 test를 출력한다.")
+    void test() throws Exception {
+        mockMvc.perform(get("/v1/posts"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("test"))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
[개꿀팁이라고 생각하는 부분]

- test를 생성하는 경우 mac에서 인텔리제이를 사용한다면 command + shift + t
- 위 명령어를 실행하면 테스트를 동일한 경로에 똑같이 생성해 줍니다.

```java
// 아래 세가지는 static method이므로 이렇게 불러와서 쓰거나 MockMvcRequestBuilder class를 선언해서  사용할 수 있습니다.
import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;


@WebMvcTest
class PostControllerTest {

    @Autowired
    private MockMvc mockMvc;

    @Test
    @DisplayName("/post 요청시 test를 출력한다.")
    void test() throws Exception {
        mockMvc.perform(get("/v1/posts"))
                .andExpect(status().isOk())
                .andExpect(MockMvcResultMatchers.content().string("test"))
                .andDo(print());
    }
}
```

- 여기서 조금 꿀팁이라고 생각되는 것은 마지막 라인의 `andDo(print())`입니다.
- 아래 내용을 실행하면 아래내용이 실행 결과로 출력됩니다.

```aidl
MockHttpServletRequest:
      HTTP Method = GET
      Request URI = /v1/posts
       Parameters = {}
          Headers = []
             Body = null
    Session Attrs = {}

Handler:
             Type = com.hodolog.hodollog.controller.PostController
           Method = com.hodolog.hodollog.controller.PostController#get()

Async:
    Async started = false
     Async result = null

Resolved Exception:
             Type = null

ModelAndView:
        View name = null
             View = null
            Model = null

FlashMap:
       Attributes = null

MockHttpServletResponse:
           Status = 200
    Error message = null
          Headers = [Content-Type:"text/plain;charset=UTF-8", Content-Length:"4"]
     Content type = text/plain;charset=UTF-8
             Body = test
    Forwarded URL = null
   Redirected URL = null
          Cookies = []
BUILD SUCCESSFUL in 5s
4 actionable tasks: 1 executed, 3 up-to-date
12:55:45 PM: 실행이 완료되었습니다 ':test --tests "com.hodolog.hodollog.controller.PostControllerTest.test"'.
```