### PR TITLE
데이터 콘텐츠 타입을 json으로 주고 받고, 과정에서 dto를선언해서 쓰는 방식에 대해서 학습 그리고 테스트 코드까지 작성…

### DIFF
--- a/note/section0.md
+++ b/note/section0.md
@@ -4,6 +4,8 @@
 
 ## 프로젝트 생성
 
+<br/>
+
 ## 컨트롤러 생성
 - 보통 SSR, SPA, 등을 많이 쓴다.
 - SSR -> Jsp, thymeleaf, mustache, freemarker -> html rendering
@@ -80,9 +82,42 @@ BUILD SUCCESSFUL in 5s
 12:55:45 PM: 실행이 완료되었습니다 ':test --tests "com.hodolog.hodollog.controller.PostControllerTest.test"'.
 ```
 
+<br/>
 
 ## POST 데이터 콘텐츠 타입
+- Http Method는 뭐가 있을까?
+- GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD, TRACE, CONNECT
+- 적어도 이 9개는 모두 알고 있어야 한다.
+- 지금은 applicaion/json으로 통신을 많이한다.
+- 예전에는 application/xml-xxx-encoding 이런식으로 썻다.
+- 코드 작성 시 생산성을 높이는 방법 1 - alt + n을 누르면 필요한 코드를 generate 할 수 있는 창이 뜬다.
+- json 타입으로 요청을 주고 받는 예시는 아래와 같다. 아래 방법에서는 json을 사용하는 방식을 사용하고 있으며 입력 요청은 dto를 생성해서 사용하는 방법을 쓰고 있음.
+```aidl
+    @PostMapping("/v1/posts4")
+    public  String post4(@RequestBody PostCreate params) {
+        log.info("params={}", params.toString());
+        return "test4";
+    }
+```
+- 테스트 코드는 아래와 같습니다.
+```aidl
+    @Test
+    @DisplayName("/v1/posts4 요청시 test4을 출력한다.")
+    void post4() throws Exception {
+        mockMvc.perform(post("/v1/posts4")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"titme\": \"제목입니다.\", \"content\": \"내용입니다.\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("test4"))
+                .andDo(print());
+    }
+```
 
+- 내 나름의 결론
+  - 일단 아래 나올 내용이지만 데이터 검증 측면에서 dto를 쓰는 것이 편할 때가 더 많습니다.
+  - 검증과 과련된 로직을 별도의 annotation으로 작성하더라도 dto를 쓰는 것이 코드 가독성 향상 목적에서는 더 좋아보입니다.
+
+<br/>
 
 ## 데이터 검증-1
 

--- a/src/main/java/com/hodolog/hodollog/controller/PostController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/PostController.java
@@ -1,17 +1,39 @@
 package com.hodolog.hodollog.controller;
 
+import com.hodolog.hodollog.dto.PostCreate;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.common.reflection.XMethod;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
+@Slf4j
 public class PostController {
 
-    @RequestMapping(method = RequestMethod.GET, path = "/v1/posts")
-    public String get() {
+//    @RequestMapping(method = RequestMethod.GET, path = "/v1/posts")
+    @PostMapping("/v1/posts")
+    public String post(@RequestParam String title, @RequestParam String content) {
+        log.info("title = {}, content={}", title, content);
         return "test";
+    }
+
+    @PostMapping("/v1/posts2")
+    public String post2(@RequestParam Map<String, String> params) {
+        log.info("params ={}", params.toString());
+        return "test2";
+    }
+
+    @PostMapping("/v1/posts3")
+    public  String post3(@ModelAttribute PostCreate params){
+        log.info("params = {}", params.toString());
+        return "test3";
+    }
+
+    @PostMapping("/v1/posts4")
+    public  String post4(@RequestBody PostCreate params) {
+        log.info("params={}", params.toString());
+        return "test4";
     }
 
 }

--- a/src/main/java/com/hodolog/hodollog/dto/PostCreate.java
+++ b/src/main/java/com/hodolog/hodollog/dto/PostCreate.java
@@ -1,0 +1,17 @@
+package com.hodolog.hodollog.dto;
+
+import lombok.ToString;
+
+@ToString
+public class PostCreate {
+    public String title;
+    public String content;
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -4,12 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 
 @WebMvcTest
@@ -19,11 +19,48 @@ class PostControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("/post 요청시 test를 출력한다.")
+    @DisplayName("/v1/posts 요청시 test를 출력한다.")
     void test() throws Exception {
-        mockMvc.perform(get("/v1/posts"))
+        mockMvc.perform(post("/v1/posts")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE) // default는 application/json입니다.
+                        .param("title", "글 제목입니다.")
+                        .param("content", "글 내용입니다. 하하"))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("test"))
+                .andExpect(content().string("test"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("/v1/posts2 요청시 test2를 출력한다.")
+    void post2() throws Exception {
+        mockMvc.perform(post("/v1/posts2")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("title", "글제목")
+                .param("content", "글 내용"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("test2"));
+    }
+
+    @Test
+    @DisplayName("/v1/posts3 요청시 test3을 출력한다.")
+    void post3() throws Exception{
+        mockMvc.perform(post("/v1/posts3")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("title", "글제목")
+                        .param("content", "글 내용"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("test3"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("/v1/posts4 요청시 test4을 출력한다.")
+    void post4() throws Exception {
+        mockMvc.perform(post("/v1/posts4")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"titme\": \"제목입니다.\", \"content\": \"내용입니다.\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("test4"))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
[ 개꿀팁이라고 생각되는 부분 ]
- 인텔리제이에서 코드를 생성하는 단축키 ( alt + n )을 사용하면 코드 생산성이 더 높아집니다. [링크](https://ifuwanna.tistory.com/241)
- 그리고 json 형태로 데이터를 주고 받아야 매개 변수로 주고 받을  수 있는 데이터의 종류가 늘어남을 인지했습니다.
- dto를 사용하면 향후 데이터 검증에 유리한 부분이 있습니다.

- json 타입으로 요청을 주고 받는 예시는 아래와 같다. 아래 방법에서는 json을 사용하는 방식을 사용하고 있으며 입력 요청은 dto를 생성해서 사용하는 방법을 쓰고 있음.
```aidl
    @PostMapping("/v1/posts4")
    public  String post4(@RequestBody PostCreate params) {
        log.info("params={}", params.toString());
        return "test4";
    }
```
- 테스트 코드는 아래와 같습니다.
```aidl
    @Test
    @DisplayName("/v1/posts4 요청시 test4을 출력한다.")
    void post4() throws Exception {
        mockMvc.perform(post("/v1/posts4")
                        .contentType(MediaType.APPLICATION_JSON)
                        .content("{\"titme\": \"제목입니다.\", \"content\": \"내용입니다.\"}"))
                .andExpect(status().isOk())
                .andExpect(content().string("test4"))
                .andDo(print());
    }
```