### PR TITLE
7 데이터 검증2

### DIFF
--- a/note/section0.md
+++ b/note/section0.md
@@ -203,25 +203,32 @@ public class PostCreate {
                       .content("{\"titme\": \"\", \"content\": \"내용입니다.\"}"))
               .andExpect(status().isOk())
               .andExpect(jsonPath("$.title").value("타이틀을 입력해주세요."))
-//                .andExpect(content().string("{}"))
               .andDo(print());
-
-      /**
-       * MockHttpServletResponse:
-       *            Status = 200
-       *     Error message = null
-       *           Headers = [Content-Type:"application/json"]
-       *      Content type = application/json
-       *              Body = {"title":"must not be blank"}
-       *     Forwarded URL = null
-       *    Redirected URL = null
-       *           Cookies = []
-       */
   }
 ```
 
 ## 데이터 검증-2
-
+- 위 방식에서 BindingResult result을 사용해서 메서드 마다 에러를 관리하게 되면 아래의 문제가 발생합니다.
+  - 에러를 매번 메서드 마다 처리해줘야 하는 문제 발생
+  - 개발자의 휴먼에러 발생
+  - 프로젝트에서 에러 관리의 일관성 저해
+  - 반복작업이 발생한다.
+  - 간지가 안난다. 개발자 스럽지 못함
+- 이를 개선하기 위해서 @ControllerAdvice를 사용하여 에러가 발생 시 해당 에러를 캐치하여 처리할 수 있음
+```java
+  @ResponseStatus(HttpStatus.BAD_REQUEST) // 응답에 보낼 것  -> 나중에는 실제 번호를 맞게 넣어야 한다.
+  @ResponseBody
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e){
+      // TODO : 이렇게 처리를 하면 에러 내용의 일관성이 부족해짐. 이것에 대해서는 별도의 처리가 필요함. -> 그리고 서비스 기획시 프론트와 백엔드간 협의가 필요한 사항임
+      ErrorResponse response =  new ErrorResponse("400", "잘못된 요청입니다.");
+      for(FieldError fieldError : e.getFieldErrors()) {
+          response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+      }
+      return response;
+  }
+```
+- 여기서 발생할 수 있는 에러 종류에 따라서 어노테이션과 메서드를 적절히 추가해서 확인한다.
 
 ## 작성글 저장1 - 게시글 저장 구현
 

--- a/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.HashMap;
-import java.util.Map;
 
 @ControllerAdvice
 public class ExceptionController {
@@ -19,19 +17,11 @@ public class ExceptionController {
     @ResponseBody
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e){
-//        FieldError fieldError = e.getFieldError();
-//        String field = fieldError.getField();
-//        String message = fieldError.getDefaultMessage();
-//
-//        Map<String, String> response  = new HashMap<>();
-//        response.put(field,message);
+        // TODO : 이렇게 처리를 하면 에러 내용의 일관성이 부족해짐. 이것에 대해서는 별도의 처리가 필요함. -> 그리고 서비스 기획시 프론트와 백엔드간 협의가 필요한 사항임
         ErrorResponse response =  new ErrorResponse("400", "잘못된 요청입니다.");
-
         for(FieldError fieldError : e.getFieldErrors()) {
             response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
         }
-
         return response;
-
     }
 }

--- a/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.hodolog.hodollog.controller;
 
+import com.hodolog.hodollog.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,13 +18,19 @@ public class ExceptionController {
     @ResponseStatus(HttpStatus.BAD_REQUEST) // 응답에 보낼 것  -> 나중에는 실제 번호를 맞게 넣어야 한다.
     @ResponseBody
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public Map<String,String> invalidRequestHandler(MethodArgumentNotValidException e){
-        FieldError fieldError = e.getFieldError();
-        String field = fieldError.getField();
-        String message = fieldError.getDefaultMessage();
+    public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e){
+//        FieldError fieldError = e.getFieldError();
+//        String field = fieldError.getField();
+//        String message = fieldError.getDefaultMessage();
+//
+//        Map<String, String> response  = new HashMap<>();
+//        response.put(field,message);
+        ErrorResponse response =  new ErrorResponse("400", "잘못된 요청입니다.");
 
-        Map<String, String> response  = new HashMap<>();
-        response.put(field,message);
+        for(FieldError fieldError : e.getFieldErrors()) {
+            response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
         return response;
 
     }

--- a/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/ExceptionController.java
@@ -1,0 +1,30 @@
+package com.hodolog.hodollog.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class ExceptionController {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST) // 응답에 보낼 것  -> 나중에는 실제 번호를 맞게 넣어야 한다.
+    @ResponseBody
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Map<String,String> invalidRequestHandler(MethodArgumentNotValidException e){
+        FieldError fieldError = e.getFieldError();
+        String field = fieldError.getField();
+        String message = fieldError.getDefaultMessage();
+
+        Map<String, String> response  = new HashMap<>();
+        response.put(field,message);
+        return response;
+
+    }
+}

--- a/src/main/java/com/hodolog/hodollog/controller/PostController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/PostController.java
@@ -74,7 +74,7 @@ public class PostController {
     }
 
     @PostMapping("/v1/posts6")
-    public  Map<String, String> post6(@RequestBody @Valid PostCreate params, BindingResult result) throws Exception {
+    public  Map<String, String> post6(@RequestBody @Valid PostCreate params /*BindingResult result*/) throws Exception {
         log.info("params={}", params.toString());
         String title = params.getTitle();
         String content = params.getContent();
@@ -86,16 +86,16 @@ public class PostController {
         // 세번 이상의 반복적인 작업은 반드시 피해야 한다. -> 코드 && 개발에 관한 모든 것
         // https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ControllerAdvice.html
 
-        if(result.hasErrors()) {
-            List<FieldError> fieldErrorList = result.getFieldErrors();
-            FieldError firstFieldError = fieldErrorList.get(0);
-            String fieldName = firstFieldError.getField();
-            String errorMessage = firstFieldError.getDefaultMessage();
-
-            Map<String, String> error = new HashMap<>();
-            error.put(fieldName, errorMessage);
-            return error;
-        }
+//        if(result.hasErrors()) {
+//            List<FieldError> fieldErrorList = result.getFieldErrors();
+//            FieldError firstFieldError = fieldErrorList.get(0);
+//            String fieldName = firstFieldError.getField();
+//            String errorMessage = firstFieldError.getDefaultMessage();
+//
+//            Map<String, String> error = new HashMap<>();
+//            error.put(fieldName, errorMessage);
+//            return error;
+//        }
 
         return Map.of();
     }

--- a/src/main/java/com/hodolog/hodollog/controller/PostController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/PostController.java
@@ -73,4 +73,31 @@ public class PostController {
         return Map.of();
     }
 
+    @PostMapping("/v1/posts6")
+    public  Map<String, String> post6(@RequestBody @Valid PostCreate params, BindingResult result) throws Exception {
+        log.info("params={}", params.toString());
+        String title = params.getTitle();
+        String content = params.getContent();
+
+        // 아래 방식의 문제점 -> 매번 메서드 마다 값을 검증 ㅐㅎ야한다. 개발자가 휴먼 에러를 일읠 수 있다. >> 검증 부분에서 버그가 발생 할 수 있다.
+        // 개발자로서 간지가 안난다.
+        // HashMap 보다는 응답 클래스를 만들어 주는 것이 중요합니다.
+        // 여러개의 응답을 줘야하는 경우 처리가 어려울 수 있음.
+        // 세번 이상의 반복적인 작업은 반드시 피해야 한다. -> 코드 && 개발에 관한 모든 것
+        // https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ControllerAdvice.html
+
+        if(result.hasErrors()) {
+            List<FieldError> fieldErrorList = result.getFieldErrors();
+            FieldError firstFieldError = fieldErrorList.get(0);
+            String fieldName = firstFieldError.getField();
+            String errorMessage = firstFieldError.getDefaultMessage();
+
+            Map<String, String> error = new HashMap<>();
+            error.put(fieldName, errorMessage);
+            return error;
+        }
+
+        return Map.of();
+    }
+
 }

--- a/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
+++ b/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
@@ -21,9 +21,13 @@ import java.util.Map;
 public class ErrorResponse {
     private final String code;
     private final String message;
-    private Map<String, String> validation = new HashMap<>();
+
+    // 가급적 Map을 직접사용하지 않는다. 꼭 사용한다면 일급 객체를 사용한다. -> 이건 일급 객체로 개선해봐야 함.
+    private final Map<String, String> validation = new HashMap<>();
 
     public void addValidation(String field, String defaultMessage) {
         this.validation.put(field, defaultMessage);
     }
+
+
 }

--- a/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
+++ b/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
@@ -22,12 +22,10 @@ public class ErrorResponse {
     private final String code;
     private final String message;
 
-    // 가급적 Map을 직접사용하지 않는다. 꼭 사용한다면 일급 객체를 사용한다. -> 이건 일급 객체로 개선해봐야 함.
+    //TODO : 가급적 Map을 직접사용하지 않는다. 꼭 사용한다면 일급 객체를 사용한다. -> 이건 일급 객체로 개선해봐야 함.
     private final Map<String, String> validation = new HashMap<>();
 
     public void addValidation(String field, String defaultMessage) {
         this.validation.put(field, defaultMessage);
     }
-
-
 }

--- a/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
+++ b/src/main/java/com/hodolog/hodollog/dto/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.hodolog.hodollog.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 이 메시지를 적용하는 것은 회사마다 다르다. 다만 보통
+ * {
+ *     "Code" : "400",
+ *     "message" : "잘못된 요청입니다.",
+ *     "validation": {
+ *         "title":"값을 입력해주세요.",
+ *     }
+ * }
+ */
+@RequiredArgsConstructor
+@Getter
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+    private Map<String, String> validation = new HashMap<>();
+
+    public void addValidation(String field, String defaultMessage) {
+        this.validation.put(field, defaultMessage);
+    }
+}

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -97,4 +97,16 @@ class PostControllerTest {
          *           Cookies = []
          */
     }
+
+    @Test
+    void post6() throws Exception {
+        // 위와 다르게 본래 테스트 대상의 메서드에서 BindingResult result를 제거해줘야 한다.
+        mockMvc.perform(post("/v1/posts6")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"titme\": \"\", \"content\": \"내용입니다.\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("타이틀을 입력해주세요."))
+//                .andExpect(content().string("{}"))
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -105,8 +105,8 @@ class PostControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"titme\": \"\", \"content\": \"내용입니다.\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value("타이틀을 입력해주세요."))
-//                .andExpect(content().string("{}"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validation.title").value("타이틀을 입력해주세요."))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -82,7 +82,6 @@ class PostControllerTest {
                         .content("{\"titme\": \"\", \"content\": \"내용입니다.\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("타이틀을 입력해주세요."))
-//                .andExpect(content().string("{}"))
                 .andDo(print());
 
         /**


### PR DESCRIPTION
[개꿀팁]]
- 입력받은 rest 요청에 대해서 한곳에서 에러를 관리합니다.
- 에러 관리의 집약성
- 개선해야 될 점은 에러 종류를 일원화 시켜서 내보내야 된다. 그리고 에러 종류가 여러가지 일 때 이를 관리 할 수 있는 일급 컬렉션을 좀 사용해야 한다.

- 이를 개선하기 위해서 @ControllerAdvice를 사용하여 에러가 발생 시 해당 에러를 캐치하여 처리할 수 있음
```java
  @ResponseStatus(HttpStatus.BAD_REQUEST) // 응답에 보낼 것  -> 나중에는 실제 번호를 맞게 넣어야 한다.
  @ResponseBody
  @ExceptionHandler(MethodArgumentNotValidException.class)
  public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e){
      // TODO : 이렇게 처리를 하면 에러 내용의 일관성이 부족해짐. 이것에 대해서는 별도의 처리가 필요함. -> 그리고 서비스 기획시 프론트와 백엔드간 협의가 필요한 사항임
      ErrorResponse response =  new ErrorResponse("400", "잘못된 요청입니다.");
      for(FieldError fieldError : e.getFieldErrors()) {
          response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
      }
      return response;
  }
```