### PR TITLE
동적 쿼리를 적용하지 않은 페이징 처리 완료

### DIFF
--- a/note/section0.md
+++ b/note/section0.md
@@ -329,6 +329,34 @@ public class Example {
 - findAll을 사용해서 조회하는 방법
 
 ## 게시글 조회 4 - 페이징 처리
+- 페이징이 필요한 경우
+  - 글이 너무 많은경우 => 비용이 너무 많이 든다.
+  - 글이 백만건 이백만건이인 경우 모두 조회하는 경우 ->DB가 뻗을 수 있다.
+  - DB -> 애플리케이션 서버로 전달하는 시간, 트래픽 비용이 많이 들어갈 수 있다.
+  - sql에서 select, limit, offset 같은 것들은 무조건 다 알고 있어야 한다.
+  - 페이징을 적용하는 방법은 간단하다. 아래 코드를 보라
+
+```java
+  @GetMapping("/pageposts")
+  public List<PostResponse> getList( Pageable pageable) { // Pageable 앞에 PageableDefault 라고 쓸 수 있다. 혹은 @PageableDefault(size = 10) 이런식으로 가능
+      return postService.getListByPage2(pageable);
+  }
+```
+
+```java
+  public List<PostResponse> getListByPage2(Pageable pageable)  {
+
+      return postRepository.findAll(pageable).stream().map(PostResponse::new).collect(Collectors.toList());
+  }
+```
+
+```yaml
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+        default-page-size: 10
+```
 
 
 ## 게시글 조회 5 - 페이징 처리(QeuryDSL)

--- a/src/main/java/com/hodolog/hodollog/controller/PostController.java
+++ b/src/main/java/com/hodolog/hodollog/controller/PostController.java
@@ -5,6 +5,8 @@ import com.hodolog.hodollog.dto.PostResponse;
 import com.hodolog.hodollog.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
@@ -109,5 +111,15 @@ public class PostController {
     public List<PostResponse> getList() {
         return postService.getList();
     }
+
+    @GetMapping("/pageposts")
+    public List<PostResponse> getList( Pageable pageable) { // Pageable 앞에 PageableDefault 라고 쓸 수 있다. 혹은 @PageableDefault(size = 10) 이런식으로 가능
+        return postService.getListByPage2(pageable);
+    }
+
+    // 아래와 같이 받으면 안된다.
+//    public List<PostResponse> getList(@RequestParam int page) {
+//        return postService.getListByPage(page);
+//    }
 
 }

--- a/src/main/java/com/hodolog/hodollog/domain/Post.java
+++ b/src/main/java/com/hodolog/hodollog/domain/Post.java
@@ -11,7 +11,7 @@ public class Post {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private Long Id;
+    private Long id;
 
     private  String title;
 

--- a/src/main/java/com/hodolog/hodollog/dto/PostResponse.java
+++ b/src/main/java/com/hodolog/hodollog/dto/PostResponse.java
@@ -13,7 +13,7 @@ public class PostResponse {
     @Builder
     public PostResponse(Post post) {
         this.id = post.getId();
-        this.title = post.getTitle().substring(0, Math.min(post.getTitle().length(), 10) ); // 요런 요구사항이 있으면 이것도 따로 테스트로 구현하는 것도 중요함
+        this.title = post.getTitle(); //.substring(0, Math.min(post.getTitle().length(), 10) ); // 요런 요구사항이 있으면 이것도 따로 테스트로 구현하는 것도 중요함
         this.content = post.getContent();
     }
 }

--- a/src/main/java/com/hodolog/hodollog/service/PostService.java
+++ b/src/main/java/com/hodolog/hodollog/service/PostService.java
@@ -6,10 +6,15 @@ import com.hodolog.hodollog.dto.PostResponse;
 import com.hodolog.hodollog.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.springframework.data.domain.Sort.*;
 
 @Slf4j
 @Service
@@ -34,5 +39,16 @@ public class PostService {
 //                                                                        .build())
 //                                                .collect(Collectors.toList());
         return postRepository.findAll().stream().map(PostResponse::new).collect(Collectors.toList());
+    }
+
+
+    public List<PostResponse> getListByPage(int page)  {
+        Pageable pageable = PageRequest.of(page,5, by(Direction.DESC, "id"));
+        return postRepository.findAll(pageable).stream().map(PostResponse::new).collect(Collectors.toList());
+    }
+
+    public List<PostResponse> getListByPage2(Pageable pageable)  {
+
+        return postRepository.findAll(pageable).stream().map(PostResponse::new).collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     username: sa
     password:
   jpa:
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: create-drop
   h2:
@@ -17,3 +17,8 @@ spring:
       enabled: true
     restart:
       enabled: true
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+        default-page-size: 10

--- a/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
+++ b/src/test/java/com/hodolog/hodollog/controller/PostControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -189,6 +191,25 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.length()", Matchers.is(100)))
                 .andExpect(jsonPath("$[0].id").value(1L))
                 .andExpect(jsonPath("$[50].title").value("제목50"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("글 여러개 조회 시 페이징 처리")
+    void getListByPage() throws Exception {
+        // given
+        List<Post> requestPosts = IntStream.range(0,30)
+                .mapToObj( i -> {
+                    return Post.builder().title("테스트 제목 - " + i)
+                            .content("둔촌주공아파트 - " + i)
+                            .build();
+                }).collect(Collectors.toList());
+
+        postRepository.saveAll(requestPosts);
+
+        // when
+        mockMvc.perform(get("/pageposts?page=1&sort=id,desc&size=5").contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/hodolog/hodollog/service/PostServiceTest.java
+++ b/src/test/java/com/hodolog/hodollog/service/PostServiceTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +85,30 @@ class PostServiceTest {
             assertEquals(postList.get(i).getTitle(), postResultList.get(i).getTitle());
             assertEquals(postList.get(i).getContent(), postResultList.get(i).getContent());
         }
+    }
 
+    @Test
+    @DisplayName("페이징 처리")
+    void getListByPaging() {
+        // sql에서 select, limit, offset 같은 것들은 무조건 다 알고 있어야 한다.
+        //given
+        List<Post> requestPosts = IntStream.range(0,30)
+                .mapToObj( i -> {
+                    return Post.builder().title("테스트 제목 - " + i)
+                            .content("둔촌주공아파트 - " + i)
+                            .build();
+                }).collect(Collectors.toList());
+
+        postRepository.saveAll(requestPosts);
+
+        List<PostResponse> posts = postService.getListByPage(0);
+
+        assertEquals(posts.size(), 5);
+        for(PostResponse p : posts) {
+            System.out.println(p.getTitle());
+        }
+        assertEquals(posts.get(0).getTitle(), "테스트 제목 - 29");
+        assertEquals(posts.get(4).getTitle(), "테스트 제목 - 25");
 
     }
 }


### PR DESCRIPTION
- 페이징이 필요한 경우
  - 글이 너무 많은경우 => 비용이 너무 많이 든다.
  - 글이 백만건 이백만건이인 경우 모두 조회하는 경우 ->DB가 뻗을 수 있다.
  - DB -> 애플리케이션 서버로 전달하는 시간, 트래픽 비용이 많이 들어갈 수 있다.
  - sql에서 select, limit, offset 같은 것들은 무조건 다 알고 있어야 한다.
  - 페이징을 적용하는 방법은 간단하다. 아래 코드를 보라

```java
  @GetMapping("/pageposts")
  public List<PostResponse> getList( Pageable pageable) { // Pageable 앞에 PageableDefault 라고 쓸 수 있다. 혹은 @PageableDefault(size = 10) 이런식으로 가능
      return postService.getListByPage2(pageable);
  }
```

```java
  public List<PostResponse> getListByPage2(Pageable pageable)  {

      return postRepository.findAll(pageable).stream().map(PostResponse::new).collect(Collectors.toList());
  }
```

```yaml
  data:
    web:
      pageable:
        one-indexed-parameters: true
        default-page-size: 10
```